### PR TITLE
Add payload url param to indices, update help modal

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -97,9 +97,8 @@
     <p class="italic mb-4">Browser-Native Secure Text Encryption</p>
     <p class="mb-4">Salty makes it easy to send strongly-encrypted messages with a shared key. It provides encryption capabilities via the browser's Web Crypto API and uses <a href="http://base91.sourceforge.net" target="_blank" class="text-sky-600 hover:underline">basE91</a> for portability.</p>
     <p class="mb-4">With Salty, you can encrypt a message as long as 185 characters and the resulting cipher will still fit in a tweet (~277 characters), making it ideal for encrypting tweets or other length-restricted communication. You can use it anywhere, though, with text of any length.</p>
-    <h2 class="text-2xl font-semibold mb-3">Coded by Neatnik</h2>
-    <p class="mb-4">Salty is an open source application written by Neatnik, and <a href="http://github.com/neatnik/salty" target="_blank" class="text-sky-600 hover:underline">available on GitHub</a>.</p>
-    <p>Detailed information can be found in the project’s <a href="https://github.com/neatnik/salty/blob/master/README.md" target="_blank" class="text-sky-600 hover:underline">README</a> file.</p>
+    <h2 class="text-2xl font-semibold mb-3">Acknowledgments</h2>
+    <p class="mb-4">Salty has been re-written in modern Typescript, but was inspired by <a href="http://github.com/neatnik/salty" target="_blank" class="text-sky-600 hover:underline">Neatnik's PHP Salty</a>.</p>
   </div>
 </div>
 

--- a/en/index.html
+++ b/en/index.html
@@ -292,6 +292,13 @@
     return text.replace(/[&<>"'`]/g, function(m) { return map[m]; });
   }
 
+  // Function to get query parameter by name
+  function getQueryParam(name) {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get(name);
+  }
+
+  // Event listener for form submission
   saltyForm.addEventListener('submit', async (event) => {
     event.preventDefault();
     const payload = payloadInput.value;
@@ -342,7 +349,7 @@
     }
   });
 
-  // Handle the "More About Salty" button click to open modal
+  // Handle the "About Salty" button click to open modal
   aboutSaltyBtn.addEventListener('click', () => {
     helpModal.classList.remove('hidden');
   });
@@ -356,6 +363,16 @@
   window.addEventListener('click', (event) => {
     if (event.target === helpModal) {
       helpModal.classList.add('hidden');
+    }
+  });
+
+  // NEW: Check for URL parameters on page load
+  document.addEventListener('DOMContentLoaded', () => {
+    const urlPayload = getQueryParam('payload');
+    if (urlPayload) {
+      payloadInput.value = decodeURIComponent(urlPayload);
+      // Optionally, you might want to automatically submit the form if a key is also provided
+      // For now, we'll just populate the payload.
     }
   });
 

--- a/index.html
+++ b/index.html
@@ -288,6 +288,13 @@
     return text.replace(/[&<>"'`]/g, function(m) { return map[m]; });
   }
 
+  // Function to get query parameter by name
+  function getQueryParam(name) {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get(name);
+  }
+
+  // Event listener for form submission
   saltyForm.addEventListener('submit', async (event) => {
     event.preventDefault();
     const payload = payloadInput.value;
@@ -352,6 +359,16 @@
   window.addEventListener('click', (event) => {
     if (event.target === helpModal) {
       helpModal.classList.add('hidden');
+    }
+  });
+
+  // NEW: Check for URL parameters on page load
+  document.addEventListener('DOMContentLoaded', () => {
+    const urlPayload = getQueryParam('payload');
+    if (urlPayload) {
+      payloadInput.value = decodeURIComponent(urlPayload);
+      // Optionally, you might want to automatically submit the form if a key is also provided
+      // For now, we'll just populate the payload.
     }
   });
 

--- a/index.html
+++ b/index.html
@@ -97,9 +97,8 @@
     <p class="italic mb-4">ブラウザネイティブな安全なテキスト暗号化</p>
     <p class="mb-4">Saltyは、共有キーで強力に暗号化されたメッセージを簡単に送信できるようにします。ブラウザのWeb Crypto API（Web暗号化API）を介して暗号化機能を提供し、<a href="http://base91.sourceforge.net" target="_blank" class="text-sky-600 hover:underline">basE91</a>を使用して移植性を高めています。</p>
     <p class="mb-4">Saltyを使えば、最大185文字のメッセージを暗号化でき、結果として得られる暗号文はツイート（約277文字）に収まるため、ツイートや文字数制限のある他の通信の暗号化に最適です。ただし、任意の長さのテキストでもどこでも使用できます。</p>
-    <h2 class="text-2xl font-semibold mb-3">Neatnikによるコーディング</h2>
-    <p class="mb-4">SaltyはNeatnikによって書かれたオープンソースアプリケーションであり、<a href="http://github.com/neatnik/salty" target="_blank" class="text-sky-600 hover:underline">GitHubで入手可能</a>です。</p>
-    <p>詳細情報は、プロジェクトの<a href="https://github.com/neatnik/salty/blob/master/README.md" target="_blank" class="text-sky-600 hover:underline">README</a>ファイルに記載されています。</p>
+    <h2 class="text-2xl font-semibold mb-3">謝辞</h2>
+    <p class="mb-4">Saltyは最新のTypeScript言語にて再開発されましたが、<a href="http://github.com/neatnik/salty" target="_blank" class="text-sky-600 hover:underline">NeatnikのPHP版Salty</a>に影響を受けています。</p>
   </div>
 </div>
 


### PR DESCRIPTION
3f7284bddef37b67e1b643fe5508baecd068426e
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sat Jun 21 15:10:58 2025 +0900

### docs(ui): update acknowledgement of Neatnik Salty
Almost everything about the app has been changed from the original Neatnik
PHP version Salty, but it's nice to acknowledge people for their work!

This updates the help modal.

aa2ad4e03deea95a69a4f56b7a0980df85863ea7
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sat Jun 21 15:00:49 2025 +0900

### feat(ui): add url param allowing pre-populating payload
If I want to send an URL to someone, and telephone them the key or PIN to
decrypt, it's better if I can pre-populate the payload for them. Adding
an url param will allow this.

Update both the Japanese (index.html) and English (en/index.html) UI files:

Read URL Parameters: The JavaScript in the `<script type="module">` block
will access window.location.search to get the query string.

Parse payload Parameter: It will then parse this string to extract the
value associated with the payload key.

Decode URL Component: The extracted value will be URL-decoded to handle
special characters (like %22 for ").

Populate Textarea: Finally, it will set the value of the payload textarea
to this decoded string.

This will allow user to construct URLs like:
`https://esolia-salty.deno.dev/en/?payload=yvC%22U0X64Xe.UUf4%...etc`



