### PR TITLE
docs(readme): add how to prepopulate payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Salty (<https://salty.esolia.pro>) is a simple, web-based application designed for secure text encryption and decryption using a shared key. It leverages the browser's built-in Web Crypto API for robust cryptographic operations, ensuring that sensitive data is processed client-side. The application also employs basE91 encoding for portability, making the encrypted output suitable for various communication channels, including those with length limitations.
 
 ## Features
+
 * Browser-Native Encryption: Utilizes the Web Crypto API for strong, client-side encryption (`AES-GCM`) and key derivation (`PBKDF2`).
 * Shared Key Security: Securely encrypt and decrypt messages using a shared passphrase.
 * Automatic Detection: Intelligently detects whether the input payload is plaintext (to be encrypted) or a Salty-encrypted cipher (to be decrypted).
@@ -12,6 +13,7 @@ Salty (<https://salty.esolia.pro>) is a simple, web-based application designed f
 * Multi-language Support: Available in English and Japanese.
 
 ## Technologies Used
+
 * Deno: Powers the server-side backend for serving static files and handling API requests (though core crypto is client-side).
 * TypeScript: Used for type-safe JavaScript development.
 * Web Crypto API: The browser's native cryptographic interface for secure operations.
@@ -85,6 +87,7 @@ Then, set this generated hex string as `SALT_HEX` in your Deno Deploy project se
 ```
 
 ### Local Development
+
 1. Clone the repository (or copy the files):
 Ensure you have `server.ts`, `salty.ts`, `index.html`, and en/index.html in your project directory.
 
@@ -113,6 +116,7 @@ deno run --allow-net --allow-read --allow-env server.ts
 4. Configure Environment Variables: Go to your project settings in Deno Deploy and add an environment variable named `SALT_HEX` with the cryptographically secure hexadecimal salt value you generated. This is critical for the application's security.
  
 ## Usage
+
 1. Open Salty in your web browser.
 2. Enter your plaintext message into the "Payload" textarea.
 3. Provide a strong key (passphrase) in the "Key" input field. This key is crucial for both encryption and decryption.
@@ -123,6 +127,7 @@ deno run --allow-net --allow-read --allow-env server.ts
 6. Use the "Copy" buttons to easily copy the generated cipher to your clipboard.
 
 ### Decryption
+
 To decrypt a Salty-encrypted message:
 
 1. Paste the Salty-encrypted message (including the BEGIN/END markers) into the "Payload" textarea. Salty will automatically detect it as an encrypted message.
@@ -131,6 +136,7 @@ To decrypt a Salty-encrypted message:
 4. The original plaintext will be displayed.
 
 ### How to Use the `/api/encrypt` and `/api/decrypt` API Endpoints
+
 These API endpoints in `server.ts` allow you to programmatically encrypt and decrypt data by sending a payload and a key to the server. It's distinct from the client-side encryption that happens directly in your browser when you use the web UI.
 
 This API is useful if you need to integrate Salty's encryption capabilities into other backend systems or services, rather than solely relying on the browser UI.
@@ -205,20 +211,43 @@ curl -X POST \
      https://your-deno-deploy-url.deno.dev/api/decrypt
 ```
 
+### How to Pre-populate the Payload Text Box
+
+If you prepare an URL using the url parameter `payload` with its value set to an url-encoded basE91 compact encrypted string, you can pre-populate the Payload text box. This makes it easy to send the encrypted string to a 3rd party, following up with the key in a separate email, or via a voice call. 
+
+```
+https://my-salty.deno.dev/?payload=yvC%22U0X64Xe.UUf4%...etc
+https://my-salty.deno.dev/en/?payload=yvC%22U0X64Xe.UUf4%...etc
+```
+
+We use the API from an operations database to prepare a URL like this for sending a password to a client via one email, followed by another email with the key. 
+
+One anomaly is, we discovered that certain `urlencode()` functions don't encode strictly enough for the function being used in javascript: `encodeURIComponent()`. If your `UrlEncode()` behaves like `encodeURIComponent()` in JavaScript, then it should already handle most of these characters correctly, but sometimes, a character will cause trouble. The telltale sign is, when you try to open the URL with the `payload` URL param, it won't populate. We fixed this by manually replacing `%` with `%25` before encoding, like so: 
+
+```
+URLEncode(Replace([Salty Encrypted Payload],"%","%25"))
+```
+
+If the `payload` URL param is not acting to pre-populate the payload text area, then you should check the string for `&, =, ?, #, +, ;, -, :` or quote marks, commas, backticks, and pre-replace them with their encoded equivalent as appropriate. 
+
 ## Important Security Notes
 ### General
+
 * Key Management: The security of your encrypted messages relies entirely on the strength and secrecy of your key. Choose a strong, unique key and never share it insecurely.
 * Salt: The `SALT_HEX` environment variable is essential for key derivation. It should be a truly random, unique value generated once per deployment. Do not reuse salts across different deployments or applications.
 * Client-Side Processing: All encryption/decryption happens directly in your browser. The server only serves the application files and does not handle your plaintext or keys (unless you use the `/api/encrypt` endpoint, which is not actively used by the client-side UI for crypto operations in this setup, but exists for potential server-side use cases if implemented).
 
 ### API
+
 * HTTPS is Crucial: Always ensure your API calls are made over HTTPS to prevent eavesdropping on your `payload`, `key`, and `X-API-Key`. Deno Deploy automatically enforces HTTPS.
 * API Key Security: Treat your `API_KEY` environment variable as a sensitive secret. Never expose it in client-side code (e.g., JavaScript in your HTML). It should only be used from secure server-side applications or environments.
 * Key Derivation: The server-side encryption also uses the `SALT_HEX` environment variable for key derivation, just like the client-side. Ensure this `SALT_HEX` is truly random and kept secret in your Deno Deploy environment variables.
 
 
 ## Contributing
+
 Salty is an open-source project. Feel free to contribute by opening issues, suggesting features, or submitting pull requests on the GitHub repository.
 
 ## License
+
 This project is released under the MIT License. See the LICENSE file for details.


### PR DESCRIPTION
e5d78b8e6c963128a08fd0ebe7bd30bc84d8fdbd
Author: James R. Cogley <rick.cogley@esolia.co.jp>
Date:   Sun Jun 22 15:42:35 2025 +0900

### docs(readme): add how to prepopulate payload
Add how to use URL param with url encoded basE91 string, and caveats



